### PR TITLE
Add support to ipbx authentication in kamailio/routing

### DIFF
--- a/wazo_router_confd/migrations/alembic/versions/ff729972d774_add_ipbx_auth_realm.py
+++ b/wazo_router_confd/migrations/alembic/versions/ff729972d774_add_ipbx_auth_realm.py
@@ -1,0 +1,24 @@
+"""add_ipbx_auth_realm
+
+Revision ID: ff729972d774
+Revises: f21060542727
+Create Date: 2019-12-06 08:47:51.645414
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ff729972d774'
+down_revision = 'f21060542727'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('ipbx', sa.Column('realm', sa.String(length=64), nullable=True))
+
+
+def downgrade():
+    op.drop_column('ipbx', 'realm')

--- a/wazo_router_confd/models/ipbx.py
+++ b/wazo_router_confd/models/ipbx.py
@@ -56,3 +56,4 @@ class IPBX(Base):
     username = Column(String(50), nullable=True)
     password = Column(String(192), nullable=True)
     password_ha1 = Column(String(64), nullable=True)
+    realm = Column(String(64), nullable=True)

--- a/wazo_router_confd/schemas/ipbx.py
+++ b/wazo_router_confd/schemas/ipbx.py
@@ -19,6 +19,7 @@ class IPBX(BaseModel):
     username: Optional[constr(max_length=50)] = None  # type: ignore
     password: Optional[constr(max_length=192)] = None  # type: ignore
     password_ha1: Optional[constr(max_length=64)] = None  # type: ignore
+    realm: Optional[constr(max_length=50)] = None  # type: ignore
 
     class Config:
         orm_mode = True
@@ -35,6 +36,7 @@ class IPBXRead(BaseModel):
     ip_address: Optional[constr(max_length=256)] = None  # type: ignore
     registered: bool = False
     username: Optional[constr(max_length=50)] = None  # type: ignore
+    realm: Optional[constr(max_length=50)] = None  # type: ignore
 
     class Config:
         orm_mode = True
@@ -52,6 +54,7 @@ class IPBXCreate(BaseModel):
     username: Optional[constr(max_length=50)] = None  # type: ignore
     password: Optional[constr(max_length=192)] = None  # type: ignore
     password_ha1: Optional[constr(max_length=64)] = None  # type: ignore
+    realm: Optional[constr(max_length=50)] = None  # type: ignore
 
 
 class IPBXUpdate(BaseModel):
@@ -66,3 +69,4 @@ class IPBXUpdate(BaseModel):
     username: Optional[str] = None  # type: ignore
     password: Optional[str] = None  # type: ignore
     password_ha1: Optional[str] = None  # type: ignore
+    realm: Optional[constr(max_length=50)] = None  # type: ignore

--- a/wazo_router_confd/services/ipbx.py
+++ b/wazo_router_confd/services/ipbx.py
@@ -34,6 +34,7 @@ def create_ipbx(db: Session, ipbx: schema.IPBXCreate) -> IPBX:
         password_ha1=password_service.hash_ha1(
             ipbx.username, domain.domain, ipbx.password
         ),
+        realm=ipbx.realm,
     )
     db.add(db_ipbx)
     db.commit()
@@ -70,6 +71,7 @@ def update_ipbx(db: Session, ipbx_id: int, ipbx: schema.IPBXUpdate) -> IPBX:
             db_ipbx.password_ha1 = (
                 password_service.hash_ha1(ipbx.username, domain.domain, ipbx.password),
             )
+        db_ipbx.realm = ipbx.realm if ipbx.realm is not None else db_ipbx.realm
         db.commit()
         db.refresh(db_ipbx)
     return db_ipbx

--- a/wazo_router_confd/tests/test_api_ipbx.py
+++ b/wazo_router_confd/tests/test_api_ipbx.py
@@ -27,6 +27,7 @@ def test_create_ipbx(app, client):
             "registered": True,
             "username": "user",
             "password": "password",
+            "realm": "realm",
         },
     )
     assert response.status_code == 200
@@ -41,6 +42,7 @@ def test_create_ipbx(app, client):
         "ip_address": "10.0.0.1",
         "registered": True,
         "username": "user",
+        "realm": "realm",
     }
 
 
@@ -89,6 +91,7 @@ def test_get_ipbxs(app, client):
         registered=True,
         username='user',
         password='password',
+        realm='realm',
     )
     session = SessionLocal(bind=app.engine)
     session.add_all([tenant, domain, ipbx])
@@ -108,6 +111,7 @@ def test_get_ipbxs(app, client):
             "tenant_id": tenant.id,
             "registered": True,
             "username": "user",
+            "realm": "realm",
         }
     ]
 
@@ -129,6 +133,7 @@ def test_get_ipbx(app, client):
         registered=True,
         username='user',
         password='password',
+        realm='realm',
     )
     session = SessionLocal(bind=app.engine)
     session.add_all([tenant, domain, ipbx])
@@ -147,6 +152,7 @@ def test_get_ipbx(app, client):
         "tenant_id": tenant.id,
         "registered": True,
         "username": "user",
+        "realm": "realm",
     }
 
 
@@ -174,6 +180,7 @@ def test_update_ipbx(app, client):
         registered=True,
         username='user',
         password='password',
+        realm='realm',
     )
     session = SessionLocal(bind=app.engine)
     session.add_all([tenant, tenant_2, domain, domain_2, ipbx])
@@ -201,6 +208,7 @@ def test_update_ipbx(app, client):
         "tenant_id": tenant_2.id,
         "registered": False,
         "username": "otheruser",
+        "realm": "realm",
     }
 
 
@@ -235,6 +243,7 @@ def test_delete_ipbx(app, client):
         ip_address="10.0.0.1",
         username='user',
         password='password',
+        realm='realm',
     )
     session = SessionLocal(bind=app.engine)
     session.add_all([tenant, domain, ipbx])
@@ -253,6 +262,7 @@ def test_delete_ipbx(app, client):
         "tenant_id": tenant.id,
         "registered": True,
         "username": "user",
+        "realm": "realm",
     }
 
 

--- a/wazo_router_confd/tests/test_api_kamailio_routing_domain.py
+++ b/wazo_router_confd/tests/test_api_kamailio_routing_domain.py
@@ -116,3 +116,76 @@ def test_kamailio_routing_domain_with_no_matching_ipbx(app, client):
     )
     assert response.status_code == 200
     assert response.json() == {"auth": None, "rtjson": {"success": False}}
+
+
+def test_kamailio_routing_domain_with_single_authenticated_ipbx(app, client):
+    from wazo_router_confd.database import SessionLocal
+    from wazo_router_confd.models.tenant import Tenant
+    from wazo_router_confd.models.domain import Domain
+    from wazo_router_confd.models.ipbx import IPBX
+
+    session = SessionLocal(bind=app.engine)
+    tenant = Tenant(name='fabio')
+    domain = Domain(domain='testdomain.com', tenant=tenant)
+    ipbx = IPBX(
+        customer=1,
+        ip_fqdn='mypbx.com',
+        domain=domain,
+        registered=True,
+        username='username',
+        password='password',
+        realm='realm',
+        tenant=tenant,
+    )
+    session.add_all([tenant, domain, ipbx])
+    session.commit()
+    #
+    request_from_name = "From name"
+    request_from_uri = "sip:100@sourcedomain.com"
+    request_from_tag = "from_tag"
+    request_to_name = "to name"
+    request_to_uri = "sip:200@testdomain.com"
+    request_to_tag = "to_tag"
+    #
+    response = client.post(
+        "/kamailio/routing",
+        json={
+            "event": "sip-routing",
+            "source_ip": "10.0.0.1",
+            "source_port": 5060,
+            "call_id": "call-id",
+            "from_name": request_from_name,
+            "from_uri": request_from_uri,
+            "from_tag": request_from_tag,
+            "to_uri": request_to_uri,
+            "to_name": request_to_name,
+            "to_tag": request_to_tag,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "auth": None,
+        "rtjson": {
+            "success": True,
+            "version": "1.0",
+            "routing": "serial",
+            "routes": [
+                {
+                    "dst_uri": "sip:%s:5060" % (ipbx.ip_fqdn),
+                    "path": "",
+                    "socket": "",
+                    "headers": {
+                        "from": {"display": request_from_name, "uri": request_from_uri},
+                        "to": {"display": request_to_name, "uri": request_to_uri},
+                        "extra": "",
+                    },
+                    "branch_flags": 8,
+                    "fr_timer": 5000,
+                    "fr_inv_timer": 30000,
+                }
+            ],
+            "auth_username": "username",
+            "auth_password": "password",
+            "realm": "realm",
+        },
+    }


### PR DESCRIPTION
Some IPBX requires authentication in order to forward packets / calls. This
commit enhances the kamailio/routing endpoint to provide auth credentials
(username, password, realm) to the rtjson response.