### PR TITLE
Fix: do not close aiopg connections after usage

### DIFF
--- a/wazo_router_confd/database.py
+++ b/wazo_router_confd/database.py
@@ -71,6 +71,9 @@ class AiopgConnectionPool(object):
     async def connect(self):
         self.pool = await aiopg.create_pool(self.dsn)
 
+    async def clear(self):
+        await self.pool.clear()
+
 
 def from_database_uri_to_dsn(database_uri: str) -> str:
     parsed_uri = urlparse(database_uri)
@@ -90,6 +93,7 @@ def setup_aiopg_database(app: FastAPI, config: dict):
     connection_pool = AiopgConnectionPool(dsn)
 
     app.add_event_handler("startup", connection_pool.connect)
+    app.add_event_handler("shutdown", connection_pool.clear)
 
     @app.middleware("http")
     async def db_aiopg_database_middleware(request: Request, call_next):

--- a/wazo_router_confd/services/domain.py
+++ b/wazo_router_confd/services/domain.py
@@ -6,7 +6,6 @@ from typing import List
 from sqlalchemy.orm import Session
 
 from wazo_router_confd.models.domain import Domain
-from wazo_router_confd.models.tenant import Tenant
 from wazo_router_confd.schemas import domain as schema
 
 

--- a/wazo_router_confd/tests/test_service_normalization.py
+++ b/wazo_router_confd/tests/test_service_normalization.py
@@ -41,12 +41,11 @@ def test_normalize_local_number_to_e164(app, database_uri, event_loop):
         dsn = from_database_uri_to_dsn(database_uri)
         pool = await aiopg.create_pool(dsn=dsn)
         async with pool.acquire() as conn:
-            try:
-                return await normalize_local_number_to_e164(
-                    conn, '+39 011 625234', profile=normalization_profile
-                )
-            finally:
-                conn.close()
+            return await normalize_local_number_to_e164(
+                conn, '+39 011 625234', profile=normalization_profile
+            )
+        pool.close()
+        await pool.wait_closed()
 
     ret = event_loop.run_until_complete(test())
     assert '36011625234' == ret
@@ -87,12 +86,11 @@ def test_normalize_e164_to_local_number(app, database_uri, event_loop):
         dsn = from_database_uri_to_dsn(database_uri)
         pool = await aiopg.create_pool(dsn=dsn)
         async with pool.acquire() as conn:
-            try:
-                return await normalize_e164_to_local_number(
-                    conn, '39011625234', profile=normalization_profile
-                )
-            finally:
-                conn.close()
+            return await normalize_e164_to_local_number(
+                conn, '39011625234', profile=normalization_profile
+            )
+        pool.close()
+        await pool.wait_closed()
 
     ret = event_loop.run_until_complete(test())
     assert '+36011625234' == ret


### PR DESCRIPTION
It was a mistake to close the connection from the pool after using it: it
lowers the performances as it needs to reconnect to PostgreSQL each time.