### PR TITLE
Fix: wazo-auth integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,11 @@ coverage:
 .PHONY: dockerfile
 dockerfile:
 	docker build -t wazopbx/wazo-router-confd:latest .
+
+.PHONY: start-auth
+start-auth:
+	docker-compose -f docker-compose.wazo-auth.yaml -f docker-compose.yaml up -d
+
+.PHONY: stop-auth
+stop-auth:
+	docker-compose -f docker-compose.wazo-auth.yaml -f docker-compose.yaml down

--- a/docker-compose.nginx.yaml
+++ b/docker-compose.nginx.yaml
@@ -1,9 +1,0 @@
-version: '2'
-services:
-  nginx:
-      image: 'wazo/nginx-ssl:latest'
-      ports:
-      - "80:80"
-      - "443:443"
-      volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf

--- a/docker-compose.wazo-auth.yaml
+++ b/docker-compose.wazo-auth.yaml
@@ -1,0 +1,24 @@
+version: '2'
+services:
+  nginx:
+      image: 'wazo/nginx-ssl:latest'
+      ports:
+      - "80:80"
+      - "443:443"
+      volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+  wazo-router-confd:
+    image: wazopbx/wazo-router-confd:latest
+    command: "wazo-router-confd \
+        --host 0.0.0.0 \
+        --port 9600 \
+        --advertise-host router-confd \
+        --advertise-port 9600 \
+        --consul-uri http://consul:8500 \
+        --database-uri postgresql://wazo:wazo@postgresql:5432/wazo \
+        --redis-uri redis://redis \
+        --wazo-auth \
+        --debug \
+        --wazo-auth-url https://wazo-auth:9497/api/auth/0.1"
+    ports:
+    - 9600:9600

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     ports:
       - '6379:6379'
   wazo-auth:
-    image: 'wazopbx/wazo-auth-mock'
+    image: 'wazopbx/wazo-auth-mock:latest'
     command: ["/usr/local/bin/wazo-auth-mock.py", "9497", "/api/auth"]
     ports:
       - '9497:9497'

--- a/wazo_router_confd/app.py
+++ b/wazo_router_confd/app.py
@@ -51,6 +51,8 @@ def get_app(config: dict):
     app.include_router(routing_group.router, prefix="/1.0", tags=['routing'])
     app.include_router(tenants.router, prefix="/1.0", tags=['tenants'])
 
+    app = setup_auth(app, config)
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
@@ -58,7 +60,5 @@ def get_app(config: dict):
         allow_methods=["*"],
         allow_headers=["*"],
     )
-
-    app = setup_auth(app, config)
 
     return app


### PR DESCRIPTION
Fix the middleware order in `app.py` to have the `setup_auth` loaded before. This fixes the `OPTIONS` method error.
Facilitate the usage of `router-confd` with `wazo-auth` in order to develop easier the portal.